### PR TITLE
mikutter 0.2.2用にGemfileを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'twitter'


### PR DESCRIPTION
mikutter 0.2.2から、bundlerを使って使用しているライブラリをインストールできるようになりました。
~/.mikutter/plugin/mikutter_update_with_media/Gemfileを書いておくと、mikutterディレクトリでbundle installした時に、自動的に読み込まれ、twitterがインストールされます。

http://mikutter.blogspot.jp/2013/05/mikutter-0221230.html
